### PR TITLE
KEH-818 | External PR Bug

### DIFF
--- a/data_logger/src/policy_checks.py
+++ b/data_logger/src/policy_checks.py
@@ -79,7 +79,7 @@ def has_external_pr(prs: list, org_members: list) -> bool:
             continue
 
         # Dependabot PRs are not considered external
-        if login == "dependabot[bot]":
+        if login == "dependabot":
             continue
 
         if login not in org_members:


### PR DESCRIPTION
This PR fixes a bug where the external PR check was returning incorrect responses. This was due to misuse of the API response.

Previously the code assumed:
```json
{
    "author": "TotalDwarf03"
}
```

Whereas the actual response was:
```json
{
    "author":
        {
            "login": "TotalDwarf03"
        }
}
```

This PR fixes this by using ["author"]["login"] for comparison instead of just ["author"]

---
The PR also includes some minor improvements:
- Dependabot PRs are now considered internal
- Collection of PR Author is now null safe. If the author is a deleted account, the API will return null.