### PR TITLE
KEH-986 + 819 | Pre Audit Tweaks

### DIFF
--- a/data_logger/src/main.py
+++ b/data_logger/src/main.py
@@ -601,6 +601,11 @@ def get_repository_batch(logger: wrapped_logging, rest: github_api_toolkit.githu
             if emails:
                 point_of_contact_missing = False
 
+        else:
+            # If a codeowners file is not found, the check should pass as this check won't apply.
+            # A CODEOWNERS file would be required and the codeowners check would fail instead.
+            point_of_contact_missing = False
+
 
         repository_data = {
             "name": repository["name"],

--- a/poetry.lock
+++ b/poetry.lock
@@ -493,8 +493,8 @@ develop = false
 [package.source]
 type = "git"
 url = "https://github.com/ONS-Innovation/github-api-package.git"
-reference = "v2.0.2"
-resolved_reference = "b6e861ee452632d2340ab40294d00e7862d000f7"
+reference = "v2.0.3"
+resolved_reference = "101a7fd5c2239ba8b18b5f5bc7bbd70f804fe43f"
 
 [[package]]
 name = "gitpython"
@@ -1700,4 +1700,4 @@ watchmedo = ["PyYAML (>=3.10)"]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.12"
-content-hash = "0710c5ba935fe0e5749a2bbdde46ac9d418fd01ac7f860a08decb074c0c54e0c"
+content-hash = "5995a735de3623a1632b4c0f998d46969d9a9bc1f13d06eca39f76374a9e478a"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ streamlit = "^1.36.0"
 boto3 = "^1.34.135"
 pandas = "^2.2.2"
 plotly = "^5.22.0"
-github-api-toolkit = {git = "https://github.com/ONS-Innovation/github-api-package.git", rev = "v2.0.2"}
+github-api-toolkit = {git = "https://github.com/ONS-Innovation/github-api-package.git", rev = "v2.0.3"}
 jwt = "^1.3.1"
 
 [tool.poetry.group.dev.dependencies]

--- a/rulemap.json
+++ b/rulemap.json
@@ -3,84 +3,98 @@
         "name": "inactive",
         "description": "The repository has not been updated in the last year.",
         "is_security_rule": true,
-        "is_policy_rule": true
+        "is_policy_rule": true,
+        "note": ""
     },
     {
         "name": "unprotected_branches",
         "description": "The repository has unprotected branches.",
         "is_security_rule": true,
-        "is_policy_rule": true
+        "is_policy_rule": true,
+        "note": ""
     },
     {
         "name": "unsigned_commits",
         "description": "One of the last 15 commits to this repository is unsigned.",
         "is_security_rule": true,
-        "is_policy_rule": true
+        "is_policy_rule": true,
+        "note": ""
     },
     {
         "name": "readme_missing",
         "description": "The repository does not have a README file.",
         "is_security_rule": false,
-        "is_policy_rule": true
+        "is_policy_rule": true,
+        "note": ""
     },
     {
         "name": "license_missing",
         "description": "The repository does not have a LICENSE file (Public Only).",
         "is_security_rule": false,
-        "is_policy_rule": true
+        "is_policy_rule": true,
+        "note": "This rule is only applicable to public repositories. All private and internal repositories are marked as compliant since the check doesn't apply."
     },
     {
         "name": "pirr_missing",
         "description": "The repository does not have a PIRR file (Private/Internal Only).",
         "is_security_rule": true,
-        "is_policy_rule": true
+        "is_policy_rule": true,
+        "note": "This rule is only applicable to private and internal repositories. All public repositories are marked as compliant since the check doesn't apply."
     },
     {
         "name": "gitignore_missing",
         "description": "The repository does not have a .gitignore file.",
         "is_security_rule": false,
-        "is_policy_rule": true
+        "is_policy_rule": true,
+        "note": ""
     },
     {
         "name": "external_pr",
         "description": "The repository has a pull request from a user which isn't a member of the organisation.",
         "is_security_rule": true,
-        "is_policy_rule": false
+        "is_policy_rule": false,
+        "note": ""
     },
     {
         "name": "breaks_naming_convention",
         "description": "The repository name does not follow ONS naming convention (No Capitals, Special Characters or Spaces).",
         "is_security_rule": false,
-        "is_policy_rule": true
+        "is_policy_rule": true,
+        "note": ""
     },
     {
         "name": "secret_scanning_disabled",
         "description": "The repository does not have secret scanning enabled (Public Only due to GitHub Advanced Security).",
         "is_security_rule": true,
-        "is_policy_rule": true
+        "is_policy_rule": true,
+        "note": "This rule is only applicable to public repositories. All private and internal repositories are marked as compliant since the check doesn't apply."
     },
     {
         "name": "push_protection_disabled",
         "description": "The repository does not have push protection enabled.",
         "is_security_rule": true,
-        "is_policy_rule": true
+        "is_policy_rule": true,
+        "note": "This rule is only applicable to public repositories. All private and internal repositories are marked as compliant since the check doesn't apply."
     },
     {
         "name": "dependabot_disabled",
         "description": "The repository does not have dependabot enabled.",
         "is_security_rule": true,
-        "is_policy_rule": true
+        "is_policy_rule": true,
+        "note": ""
     },
     {
         "name": "codeowners_missing",
         "description": "The repository does not have a CODEOWNERS file.",
         "is_security_rule": false,
-        "is_policy_rule": true
+        "is_policy_rule": true,
+        "note": ""
     },
     {
         "name": "point_of_contact_missing",
         "description": "A contact email address cannot be found from the CODEOWNERS file.",
         "is_security_rule": true,
-        "is_policy_rule": true
+        "is_policy_rule": true,
+        "note": "This rule will only check if a point of contact email address can be found from the CODEOWNERS file. If the CODEOWNERS file is missing, this rule will not be triggered and be marked as compliant."
     }
 ]

--- a/src/app.py
+++ b/src/app.py
@@ -96,6 +96,9 @@ def load_repositories(_s3, load_date: datetime.date) -> pd.DataFrame | str:
 
     df_repositories = pd.json_normalize(json_data)
 
+    # Update repository_type to be title case
+    df_repositories["type"] = df_repositories["type"].str.title()
+
     return df_repositories
     
 
@@ -322,7 +325,7 @@ with repository_tab:
 
     repository_type = st.selectbox(
         "Repository Type",
-        ["all", "public", "private", "internal"],
+        ["All", "Public", "Private", "Internal"],
         key="repos_repo_type",
     )
 
@@ -353,8 +356,8 @@ with repository_tab:
         df_repositories = df_repositories.drop(columns=rules_to_exclude)
 
         # Filter the DataFrame by the selected repository type
-        if repository_type != "all":
-            df_repositories = df_repositories.loc[df_repositories["repository_type"] == repository_type.upper()]
+        if repository_type != "All":
+            df_repositories = df_repositories.loc[df_repositories["repository_type"] == repository_type]
 
         # Filter the DataFrame by the selected date range
         df_repositories["created_at"] = pd.to_datetime(df_repositories["created_at"], errors="coerce").dt.tz_localize(
@@ -620,10 +623,12 @@ with secret_tab:
         ]
 
         ## Repository Type Filter
-        type_list = ["All", "Public", "Private", "Internal", "Archived"]
+        type_list = ["All", "All (Except Archived)", "Public", "Private", "Internal", "Archived"]
         selected_type = col3.selectbox("Select Repository Type", type_list)
 
-        if selected_type != "All":
+        if selected_type == "All (Except Archived)":
+            df_secret_scanning = df_secret_scanning.loc[df_secret_scanning["Type"] != "Archived"]
+        elif selected_type != "All":
             df_secret_scanning = df_secret_scanning.loc[df_secret_scanning["Type"] == selected_type]
 
         if len(df_secret_scanning) == 0:

--- a/src/app.py
+++ b/src/app.py
@@ -419,9 +419,14 @@ with repository_tab:
         notes_list = []
 
         for i in range(0, len(selected_rules)):
-            if rulemap[i]["note"] != "":
+            # Get the rule from the rulemap
+            rule = next((
+                item for item in rulemap if item["name"] == selected_rules[i]
+            ), None)
+
+            if rule["note"] != "":
                 notes_list.append(
-                    f"- **{selected_rules[i].replace('_', ' ').title()}:** {rulemap[i]['note']}"
+                    f"- **{rule["name"].replace('_', ' ').title()}:** {rule["note"]}"
                 )
 
         if len(notes_list) > 0:

--- a/src/app.py
+++ b/src/app.py
@@ -66,7 +66,7 @@ def get_last_modified(client: boto3.client, file_names: list[str]) -> dict:
             response = client.head_object(Bucket=bucket_name, Key=file)
             last_modified = response["LastModified"]
             file_key = file.split(".")[0]
-            last_modified_timestamps[file_key] = last_modified.strftime('%Y-%m-%d %H:%M:%S')
+            last_modified_timestamps[file_key] = last_modified.strftime('%Y-%m-%d @ %H:%M')
         except Exception as e:
             # Handle the error for a specific file here.
             print(f"Error processing file {file}: {e}")

--- a/src/app.py
+++ b/src/app.py
@@ -362,6 +362,10 @@ with repository_tab:
     with col2:
         end_date = st.date_input("End Date", (datetime.now() + timedelta(days=1)).date(), key="end_date_repo")
 
+    st.caption(
+        "**Please Note:** The above date range is used to filter the creation date of repositories."
+    )
+
     if end_date < start_date:
         st.error("End date cannot be before start date.")
         st.stop()
@@ -433,6 +437,28 @@ with repository_tab:
             st.caption(
                 "**Note:** All rules are interpreted from ONS' [GitHub Usage Policy](https://officenationalstatistics.sharepoint.com/sites/ONS%5FDDaT%5FCommunities/Software%20Engineering%20Policies/Forms/AllItems.aspx?id=%2Fsites%2FONS%5FDDaT%5FCommunities%2FSoftware%20Engineering%20Policies%2FSoftware%20Engineering%20Policies%2FApproved%2FPDF%2FGitHub%20Usage%20Policy%2Epdf&parent=%2Fsites%2FONS%5FDDaT%5FCommunities%2FSoftware%20Engineering%20Policies%2FSoftware%20Engineering%20Policies%2FApproved%2FPDF)."
             )
+
+        st.divider()
+
+        st.subheader(":blue-background[Rule Notes]")
+
+        notes_list = []
+
+        for i in range(0, len(selected_rules)):
+            if rulemap[i]["note"] != "":
+                notes_list.append(
+                    f"- {selected_rules[i].replace('_', ' ').title()}: {rulemap[i]['note']}"
+                )
+
+        if len(notes_list) > 0:
+            col1a, col1b = st.columns(2)
+            
+            for i in range(0, len(notes_list)):
+                if i % 2 == 0:
+                    col1a.write(notes_list[i])
+                else:
+                    col1b.write(notes_list[i])
+                
 
         st.divider()
 

--- a/src/app.py
+++ b/src/app.py
@@ -398,15 +398,19 @@ with repository_tab:
 
             col1a, col1b = st.columns(2)
             for i in range(0, len(selected_rules)):
+                rule_name = selected_rules[i].replace("_", " ").title()
+
                 if i % 2 == 0:
-                    col1a.write(f"- {selected_rules[i].replace('_', ' ').title()}")
+                    col1a.write(f"- {rule_name}")
                 else:
-                    col1b.write(f"- {selected_rules[i].replace('_', ' ').title()}")
+                    col1b.write(f"- {rule_name}")
 
         with st.expander("See Rule Descriptions"):
             st.subheader("Rule Descriptions")
             for rule in rulemap:
-                st.write(f"- **{rule['name'].replace('_', ' ').title()}:** {rule['description']}")
+                rule_name = rule['name'].replace('_', ' ').title()
+
+                st.write(f"- **{rule_name}:** {rule['description']}")
 
             st.caption(
                 "**Note:** All rules are interpreted from ONS' [GitHub Usage Policy](https://officenationalstatistics.sharepoint.com/sites/ONS%5FDDaT%5FCommunities/Software%20Engineering%20Policies/Forms/AllItems.aspx?id=%2Fsites%2FONS%5FDDaT%5FCommunities%2FSoftware%20Engineering%20Policies%2FSoftware%20Engineering%20Policies%2FApproved%2FPDF%2FGitHub%20Usage%20Policy%2Epdf&parent=%2Fsites%2FONS%5FDDaT%5FCommunities%2FSoftware%20Engineering%20Policies%2FSoftware%20Engineering%20Policies%2FApproved%2FPDF)."
@@ -424,9 +428,11 @@ with repository_tab:
                 item for item in rulemap if item["name"] == selected_rules[i]
             ), None)
 
-            if rule["note"] != "":
+            if rule["note"]:
+                rule_name = rule["name"].replace('_', ' ').title()
+
                 notes_list.append(
-                    f"- **{rule["name"].replace('_', ' ').title()}:** {rule["note"]}"
+                    f"- **{rule_name}:** {rule["note"]}"
                 )
 
         if len(notes_list) > 0:

--- a/src/app.py
+++ b/src/app.py
@@ -432,7 +432,7 @@ with repository_tab:
         with st.expander("See Rule Descriptions"):
             st.subheader("Rule Descriptions")
             for rule in rulemap:
-                st.write(f"- {rule['name'].replace('_', ' ').title()}: {rule['description']}")
+                st.write(f"- **{rule['name'].replace('_', ' ').title()}:** {rule['description']}")
 
             st.caption(
                 "**Note:** All rules are interpreted from ONS' [GitHub Usage Policy](https://officenationalstatistics.sharepoint.com/sites/ONS%5FDDaT%5FCommunities/Software%20Engineering%20Policies/Forms/AllItems.aspx?id=%2Fsites%2FONS%5FDDaT%5FCommunities%2FSoftware%20Engineering%20Policies%2FSoftware%20Engineering%20Policies%2FApproved%2FPDF%2FGitHub%20Usage%20Policy%2Epdf&parent=%2Fsites%2FONS%5FDDaT%5FCommunities%2FSoftware%20Engineering%20Policies%2FSoftware%20Engineering%20Policies%2FApproved%2FPDF)."
@@ -447,7 +447,7 @@ with repository_tab:
         for i in range(0, len(selected_rules)):
             if rulemap[i]["note"] != "":
                 notes_list.append(
-                    f"- {selected_rules[i].replace('_', ' ').title()}: {rulemap[i]['note']}"
+                    f"- **{selected_rules[i].replace('_', ' ').title()}:** {rulemap[i]['note']}"
                 )
 
         if len(notes_list) > 0:


### PR DESCRIPTION
## Overview

This PR includes a range of ease of use features to make auditing easier.

### KEH-986

- Added check notes to provide additional information about the various policy checks (i.e. if a rule only applies to public repositories, check notes informs the use that all private and internal repositories will automatically pass the check).
- Add notes to all date filters to say which type of date is being filtered.
- Adjust Point of Contact check to pass repositories that do not have a CODEOWNERS file.
- Added Repository Type filter for Secret Scanning + Dependabot

### KEH-819

- Rewrite to backend Lambda to store individual Secret Scanning and Dependabot alerts (minus sensitive information)
- Added date filters for both Secret Scanning + Dependabot

## How to Test

1. Run the Dashboard Locally
2. Use sdp-dev credentials in order to use new dataset format (I've pre-populated the S3 bucket with the Lambda's new output.

Alternatively, look at the deployed version on sdp-dev.

## Additional Notes

MkDocs has not been updated with this PR because a refactor is coming soon. Documentation will be updated there as it is wildly out of date anyway and not fit for purpose.