### PR TITLE
KEH-1060 | Add Repository URL to Secret Scanning Data

### DIFF
--- a/data_logger/src/main.py
+++ b/data_logger/src/main.py
@@ -899,8 +899,9 @@ def get_secret_scanning_data(logger: wrapped_logging, rest: github_api_toolkit.g
 
             formatted_alert = {
                 "repository": alert["repository"]["name"],
+                "repository_url": alert["repository"]["html_url"],
                 "creation_date": alert["created_at"],
-                "url": alert["html_url"]
+                "alert_url": alert["html_url"],
             }
 
             secret_scanning_data.append(formatted_alert)

--- a/docs/data_logger/secret_scanning.md
+++ b/docs/data_logger/secret_scanning.md
@@ -14,7 +14,7 @@ This dataset includes all open alerts within the threshold, regardless of whethe
         "repository": "{repo}",
         "repository_url": "https://github.com/{org}/{repo}",
         "creation_date": "2024-12-11T23:54:00Z",
-        "url": "https://github.com/{org}/{repo}/security/secret-scanning/{alert_id}"
+        "alert_url": "https://github.com/{org}/{repo}/security/secret-scanning/{alert_id}"
     },
 ]
 ```

--- a/docs/data_logger/secret_scanning.md
+++ b/docs/data_logger/secret_scanning.md
@@ -12,6 +12,7 @@ This dataset includes all open alerts within the threshold, regardless of whethe
 [    
     {
         "repository": "{repo}",
+        "repository_url": "https://github.com/{org}/{repo}",
         "creation_date": "2024-12-11T23:54:00Z",
         "url": "https://github.com/{org}/{repo}/security/secret-scanning/{alert_id}"
     },

--- a/src/secret_scanning/collection.py
+++ b/src/secret_scanning/collection.py
@@ -32,9 +32,13 @@ def load_secret_scanning(_s3, bucket: str) -> pd.DataFrame | None:
     # Rename the columns to be more readable
     df_secret_scanning.columns = [
         "Repository",
+        "Repository URL",
         "Creation Date",
         "URL",
     ]
+
+    # Remove repository URL since it isn't used (Database requirement only)
+    df_secret_scanning = df_secret_scanning.drop(columns=["Repository URL"])
 
     # Add Alert Age (Days) to the DataFrame
     df_secret_scanning["Alert Age (Days)"] = datetime.now() - pd.to_datetime(df_secret_scanning["Creation Date"]).dt.tz_localize(None)


### PR DESCRIPTION
## Overview

Adds Repository URL to `secret_scanning.json`. This is so that the database is supported and adds no extra functionality to the Streamlit app.

## How to Test

The UI does not need testing as the new column is removed when the data is collected from S3.

To test the lambda, run it locally using the README.

**Ensure that `write_to_s3` is set to `false` in `config.json`. Writing the new format to S3 will break the current deployment.**

## Documentation

The documentation has been updated appropriately.