### PR TITLE
bug: Assign Europe/London timezone to ECS container.

### DIFF
--- a/terraform/dashboard/main.tf
+++ b/terraform/dashboard/main.tf
@@ -61,6 +61,10 @@ resource "aws_ecs_task_definition" "ecs_service_definition" {
         {
           name  = "GITHUB_APP_CLIENT_ID"
           value = var.github_app_client_id
+        },
+        {
+          name  = "TZ"
+          value = "Europe/London"
         }
       ],
       logConfiguration = {


### PR DESCRIPTION
This PR updates the Terraform for the ECS Task to use the Europe/London timezone instead of UTC.