### PR TITLE
KEH-2058 - ECS SCP Fixes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,10 @@ RUN poetry install --only main --no-root
 # Expose the port the app runs on
 EXPOSE 8501
 
+# Run as non-root user for security
+RUN useradd -m appuser
+USER appuser
+
 # Run the dashboard
 # Note: ENTRYPOINT cannot be overriden by docker run command
 ENTRYPOINT ["poetry", "run", "streamlit", "run", "src/app.py", "--server.port=8501", "--server.address=0.0.0.0"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,15 +10,15 @@ WORKDIR /app
 # Copy the current directory contents into the container at /app
 COPY . /app
 
+# Run as non-root user for security
+RUN useradd -m appuser
+USER appuser
+
 # Run poetry install --without dev
 RUN poetry install --only main --no-root 
 
 # Expose the port the app runs on
 EXPOSE 8501
-
-# Run as non-root user for security
-RUN useradd -m appuser
-USER appuser
 
 # Run the dashboard
 # Note: ENTRYPOINT cannot be overriden by docker run command

--- a/terraform/dashboard/main.tf
+++ b/terraform/dashboard/main.tf
@@ -33,6 +33,7 @@ resource "aws_ecs_task_definition" "ecs_service_definition" {
           appProtocol   = "http"
         }
       ],
+      readonlyRootFilesystem = true,
       environment = [
         {
           name  = "AWS_ACCESS_KEY_ID"

--- a/terraform/dashboard/main.tf
+++ b/terraform/dashboard/main.tf
@@ -118,10 +118,7 @@ resource "aws_ecs_service" "application" {
   network_configuration {
     subnets         = data.terraform_remote_state.ecs_infrastructure.outputs.private_subnets
     security_groups = [aws_security_group.allow_rules_service.id]
-
-    # TODO: The container fails to launch unless a public IP is assigned
-    # For a private ip, you would need to use a NAT Gateway?
-    assign_public_ip = true
+    assign_public_ip = false
   }
 
 }


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

### What

This PR amends the policy dashboard to apply with new AWS Organisational settings.

This PR does the following:

- Change dashboard container to run as non-root
- Read only file system for dashboard container
- Remove ECS public IP since NAT gateway and routing is in place.

### Testing

Have any new tests been added as part of this issue? If not, try to explain why test coverage is not needed here.

- [ ] Yes
- [x] No
Please write a brief description of why test coverage is not necessary here.
- [ ] Not as part of this ticket. (Could be done at a later point)

### Documentation

Has any new documentation been written as part of this issue? We should try to keep documentation up to date 
as new code is added, rather than leaving it for the future.

- [ ] Yes
- [x] No
Please write a brief description of why documentation is not necessary here.
- [ ] Not as part of this ticket. (Could be done at a later point)

### Related issues

KEH-2058 (Jira)

### How to review

N/A

Without these changes I couldn't deploy so the fact it deploys means it works 🎉 